### PR TITLE
Update ActivityTraceId.xml

### DIFF
--- a/xml/System.Diagnostics/ActivityTraceId.xml
+++ b/xml/System.Diagnostics/ActivityTraceId.xml
@@ -405,7 +405,7 @@ The characters in <paramref name="idData" /> are not all lower-case hexadecimal 
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Returns a 16-character hexadecimal string that represents this span ID.</summary>
+        <summary>Returns a 32-character hexadecimal string that represents this span ID.</summary>
         <returns>The 32-character hexadecimal string representation of this trace ID.</returns>
         <remarks>To be added.</remarks>
       </Docs>


### PR DESCRIPTION
Correct the size of string returned from ToHexString

As mentioned in #9136 the documentation of ToHexString contradicts itself saying it'll return a 16 bit character string while returning a 32 bit character string.

## Summary

Describe your changes here.

Fixes #9136
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

